### PR TITLE
Fix nullable warnings in benchmark project

### DIFF
--- a/Distractive.Formatters.Benchmark/GreatFriends.ThaiBahtText/ThaiBahtTextUtil.cs
+++ b/Distractive.Formatters.Benchmark/GreatFriends.ThaiBahtText/ThaiBahtTextUtil.cs
@@ -2,6 +2,8 @@
 using System.Diagnostics.Contracts;
 using System.Text;
 
+#nullable disable
+
 namespace GreatFriends.ThaiBahtText
 {
 

--- a/Distractive.Formatters.Benchmark/NumberToThaiText/NumToThaiTextConverter.cs
+++ b/Distractive.Formatters.Benchmark/NumberToThaiText/NumToThaiTextConverter.cs
@@ -4,6 +4,8 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
+#nullable disable
+
 namespace NumberToThaiText
 {
     public class NumToThaiTextConverter

--- a/Distractive.Formatters.Benchmark/NumberToThaiText/ThaiText.cs
+++ b/Distractive.Formatters.Benchmark/NumberToThaiText/ThaiText.cs
@@ -4,6 +4,8 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
+#nullable disable
+
 namespace NumberToThaiText
 {
     public class ThaiText


### PR DESCRIPTION
External libraries are old and provided for comparison only, so no need to enable nullable in those libraries